### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ packages installed:
 
 * make
 * selinux-policy
+* selinux-policy-devel
 * policycoreutils-python
 
 ### Build


### PR DESCRIPTION
`selinux-policy-devel` is needed but not mentioned
Otherwise helper Makefiles are missing from /var/lib
